### PR TITLE
Filter out loopback ip from /etc/hosts

### DIFF
--- a/alfredssh.py
+++ b/alfredssh.py
@@ -109,7 +109,7 @@ def parse_file(open_file, parser):
         'hosts':
             (
                 host for line in open_file
-                if not line.startswith('#')
+                if not line.startswith('#') and not line.startswith("127.0.0.1")
                 for host in line.split()[1:]
                 if host != 'broadcasthost'
             ),


### PR DESCRIPTION
I added a condition to filter out loopback address from /etc/hosts, because I have a lot of websites that I want to block and I map it to `127.0.0.1` for all of them in my host file. It might be useful for other people who do the same thing as me. So feel free to accept or reject. Overall your code is very useful. Thanks for developing it. 👍