### PR TITLE
Include system-wide known_hosts files

### DIFF
--- a/alfredssh.py
+++ b/alfredssh.py
@@ -159,6 +159,8 @@ def complete():
     for results in (
         fetch_file('~/.ssh/config', 'ssh_config', 'ssh_config', 'ssh_config'),
         fetch_file('~/.ssh/known_hosts', 'known_hosts', 'known_hosts', 'known_hosts'),
+        fetch_file('/etc/ssh/ssh_known_hosts', 'systemwide_known_hosts', 'known_hosts', 'known_hosts'),
+        fetch_file('/usr/local/etc/ssh/ssh_known_hosts', 'localetc_known_hosts', 'known_hosts', 'known_hosts'),
         fetch_file('/etc/hosts', 'hosts', 'hosts', 'hosts'),
         fetch_bonjour()
     ):


### PR DESCRIPTION
Include the system-wide known_hosts, including /etc/ssh/ssh_known_hosts (default) and /usr/local/etc/ssh/ssh_known_hosts (Homebrew openssh default)